### PR TITLE
Fix for link to Structures in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DictShield
 
 This project is now called Structures and exists over here:
-[https://github.com/j2labs/structures])https://github.com/j2labs/structures)
+[https://github.com/j2labs/structures](https://github.com/j2labs/structures)
 
 This code and documentation is here to preserve amusing history of this project.
 


### PR DESCRIPTION
Needed a ( instead of a ).
